### PR TITLE
Fix the name of the exported merge file

### DIFF
--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -50,6 +50,10 @@ const DownloadButton = (props) => {
 
     const handleClickExport = () => {
         console.info("Downloading merge " + merge.process + "...");
+        // The getTimezoneOffset() method returns the difference, in minutes, between UTC and local time.
+        // The offset is positive if the local timezone is behind UTC and negative if it is ahead
+        // On service side, the opposite behaviour is expected (offset is expected to be negative if the local timezone is behind UTC and positive if it is ahead)
+        // This explains the "-" sign to get the expected offset value for the service
         window.open(getExportMergeUrl(merge.process, merge.date.toISOString(), -new Date().getTimezoneOffset()), DownloadIframe);
     };
 

--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -50,7 +50,7 @@ const DownloadButton = (props) => {
 
     const handleClickExport = () => {
         console.info("Downloading merge " + merge.process + "...");
-        window.open(getExportMergeUrl(merge.process, merge.date.toISOString()), DownloadIframe);
+        window.open(getExportMergeUrl(merge.process, merge.date.toISOString(), -new Date().getTimezoneOffset()), DownloadIframe);
     };
 
     return (

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -68,7 +68,9 @@ function getUrlWithToken(baseUrl) {
     return baseUrl + '?access_token=' + getToken();
 }
 
-export function getExportMergeUrl(process, date) {
-    const url = PREFIX_ORCHESTRATOR_QUERIES + '/v1/' + process + '/' + date + '/export/XIIDM';
-    return getUrlWithToken(url);
+export function getExportMergeUrl(process, date, timeZoneoffset) {
+    const url = PREFIX_ORCHESTRATOR_QUERIES + '/v1/' + process + '/' + date + '/export/XIIDM'
+
+    return getUrlWithToken(url) + '&timeZoneOffset=' +
+        timeZoneoffset;
 }


### PR DESCRIPTION
The name of the file created by the export merge functionality was incorrect, it did not contain the correct process date (i.e. the date as seen by the user on the merge-app). This PR allows to send the user TimeZone offset in the export request in order to generate a correct file name on the service side.