### PR TITLE
feat(authorization): enable code flow by config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@emotion/react": "^11.8.2",
                 "@emotion/styled": "^11.8.1",
-                "@gridsuite/commons-ui": "0.32.0",
+                "@gridsuite/commons-ui": "0.41.0",
                 "@mui/icons-material": "^5.5.1",
                 "@mui/lab": "^5.0.0-alpha.75",
                 "@mui/material": "^5.5.3",
@@ -27,6 +27,7 @@
                 "prop-types": "^15.7.2",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0",
+                "react-hook-form": "^7.41.0",
                 "react-intl": "^6.0.0",
                 "react-redux": "^8.0.0",
                 "react-router-dom": "^6.0.0",
@@ -38,7 +39,8 @@
                 "reconnecting-websocket": "^4.4.0",
                 "redux": "^4.0.5",
                 "typeface-roboto": "^1.0.0",
-                "typescript": "^5.1.3"
+                "typescript": "^5.1.3",
+                "yup": "^1.0.0"
             },
             "devDependencies": {
                 "eslint-config-prettier": "^8.0.0",
@@ -2576,9 +2578,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.32.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.32.0.tgz",
-            "integrity": "sha512-j2iuj+aCZqvwMd7IvuRqGjUucYDDI5tQf/1oXQh6J3VHH9T98pkSZa4Qr+MFNcCzpsv2HbaREbfrVi+faSEjhg==",
+            "version": "0.41.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.41.0.tgz",
+            "integrity": "sha512-GxRZBWhvXxVKgXAg6HIWX+t2UpCTdgkKlnwjceLY5FxaZcBCaNAISzz7HNGYtAvj3gePNlKGSeGNNQcoOe9pRA==",
             "dependencies": {
                 "autosuggest-highlight": "^3.2.0",
                 "clsx": "^1.0.4",
@@ -2591,21 +2593,23 @@
                 "react-virtualized": "^9.21.2"
             },
             "engines": {
-                "node": ">=12 <=14",
-                "npm": "<=6"
+                "node": ">=18",
+                "npm": ">=9"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.8.1",
                 "@emotion/styled": "^11.8.1",
+                "@hookform/resolvers": "^3.0.0",
                 "@mui/icons-material": "^5.5.0",
                 "@mui/lab": "^5.0.0-alpha.72",
                 "@mui/material": "^5.5.0",
-                "@mui/styles": "^5.5.0",
-                "notistack": "^2.0.3",
+                "notistack": "^3.0.0",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0",
+                "react-hook-form": "^7.41.0",
                 "react-intl": "^6.0.0",
-                "react-router-dom": "^6.0.0"
+                "react-router-dom": "^6.0.0",
+                "yup": "^1.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -14845,6 +14849,11 @@
                 "react-is": "^16.13.1"
             }
         },
+        "node_modules/property-expr": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+            "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -15145,6 +15154,21 @@
             "version": "6.0.11",
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
             "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+        },
+        "node_modules/react-hook-form": {
+            "version": "7.48.2",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.48.2.tgz",
+            "integrity": "sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==",
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/react-hook-form"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17 || ^18"
+            }
         },
         "node_modules/react-intl": {
             "version": "6.4.1",
@@ -17012,6 +17036,11 @@
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
         },
+        "node_modules/tiny-case": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+            "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+        },
         "node_modules/tiny-warning": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -17066,6 +17095,11 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "node_modules/toposort": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
         },
         "node_modules/tough-cookie": {
             "version": "4.1.2",
@@ -18368,6 +18402,28 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yup": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/yup/-/yup-1.3.2.tgz",
+            "integrity": "sha512-6KCM971iQtJ+/KUaHdrhVr2LDkfhBtFPRnsG1P8F4q3uUVQ2RfEM9xekpha9aA4GXWJevjM10eDcPQ1FfWlmaQ==",
+            "dependencies": {
+                "property-expr": "^2.0.5",
+                "tiny-case": "^1.0.3",
+                "toposort": "^2.0.2",
+                "type-fest": "^2.19.0"
+            }
+        },
+        "node_modules/yup/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "engines": {
+                "node": ">=12.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
                 "prop-types": "^15.7.2",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0",
-                "react-hook-form": "^7.41.0",
                 "react-intl": "^6.0.0",
                 "react-redux": "^8.0.0",
                 "react-router-dom": "^6.0.0",
@@ -39,14 +38,15 @@
                 "reconnecting-websocket": "^4.4.0",
                 "redux": "^4.0.5",
                 "typeface-roboto": "^1.0.0",
-                "typescript": "^5.1.3",
-                "yup": "^1.0.0"
+                "typescript": "^5.1.3"
             },
             "devDependencies": {
                 "eslint-config-prettier": "^8.0.0",
                 "eslint-plugin-prettier": "^4.0.0",
                 "http-proxy-middleware": "^2.0.0",
-                "prettier": "^2.0.5"
+                "prettier": "^2.0.5",
+                "react-hook-form": "^7.48.2",
+                "yup": "^1.3.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -14852,7 +14852,8 @@
         "node_modules/property-expr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
-            "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+            "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+            "dev": true
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -15159,6 +15160,7 @@
             "version": "7.48.2",
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.48.2.tgz",
             "integrity": "sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==",
+            "dev": true,
             "engines": {
                 "node": ">=12.22.0"
             },
@@ -17039,7 +17041,8 @@
         "node_modules/tiny-case": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
-            "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+            "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+            "dev": true
         },
         "node_modules/tiny-warning": {
             "version": "1.0.3",
@@ -17099,7 +17102,8 @@
         "node_modules/toposort": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+            "dev": true
         },
         "node_modules/tough-cookie": {
             "version": "4.1.2",
@@ -18411,6 +18415,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/yup/-/yup-1.3.2.tgz",
             "integrity": "sha512-6KCM971iQtJ+/KUaHdrhVr2LDkfhBtFPRnsG1P8F4q3uUVQ2RfEM9xekpha9aA4GXWJevjM10eDcPQ1FfWlmaQ==",
+            "dev": true,
             "dependencies": {
                 "property-expr": "^2.0.5",
                 "tiny-case": "^1.0.3",
@@ -18422,6 +18427,7 @@
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
             "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "dev": true,
             "engines": {
                 "node": ">=12.20"
             },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
-        "@gridsuite/commons-ui": "0.32.0",
+        "@gridsuite/commons-ui": "0.41.0",
         "@mui/icons-material": "^5.5.1",
         "@mui/lab": "^5.0.0-alpha.75",
         "@mui/material": "^5.5.3",
@@ -23,6 +23,7 @@
         "prop-types": "^15.7.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "react-hook-form": "^7.41.0",
         "react-intl": "^6.0.0",
         "react-redux": "^8.0.0",
         "react-router-dom": "^6.0.0",
@@ -34,7 +35,8 @@
         "reconnecting-websocket": "^4.4.0",
         "redux": "^4.0.5",
         "typeface-roboto": "^1.0.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.1.3",
+        "yup": "^1.0.0"
     },
     "scripts": {
         "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "prop-types": "^15.7.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-hook-form": "^7.41.0",
         "react-intl": "^6.0.0",
         "react-redux": "^8.0.0",
         "react-router-dom": "^6.0.0",
@@ -35,8 +34,7 @@
         "reconnecting-websocket": "^4.4.0",
         "redux": "^4.0.5",
         "typeface-roboto": "^1.0.0",
-        "typescript": "^5.1.3",
-        "yup": "^1.0.0"
+        "typescript": "^5.1.3"
     },
     "scripts": {
         "start": "react-scripts start",
@@ -67,9 +65,11 @@
         ]
     },
     "devDependencies": {
+        "eslint-config-prettier": "^8.0.0",
+        "eslint-plugin-prettier": "^4.0.0",
         "http-proxy-middleware": "^2.0.0",
         "prettier": "^2.0.5",
-        "eslint-config-prettier": "^8.0.0",
-        "eslint-plugin-prettier": "^4.0.0"
+        "react-hook-form": "^7.48.2",
+        "yup": "^1.3.2"
     }
 }

--- a/public/env.json
+++ b/public/env.json
@@ -1,4 +1,3 @@
 {
-    "appsMetadataServerUrl": "http://localhost:8070",
-    "authorizationCodeFlowFeatureFlag": false
+    "appsMetadataServerUrl": "http://localhost:8070"
 }

--- a/public/env.json
+++ b/public/env.json
@@ -1,3 +1,4 @@
 {
-    "appsMetadataServerUrl": "http://localhost:8070"
+    "appsMetadataServerUrl": "http://localhost:8070",
+    "authorizationCodeFlowFeatureFlag": false
 }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -38,6 +38,7 @@ import Process from './process';
 
 import {
     connectNotificationsWsUpdateConfig,
+    fetchAuthorizationCodeFlowFeatureFlag,
     fetchConfigParameter,
     fetchConfigParameters,
     fetchValidateUser,
@@ -141,12 +142,16 @@ const App = () => {
     });
 
     useEffect(() => {
-        initializeAuthenticationProd(
-            dispatch,
-            initialMatchSilentRenewCallbackUrl != null,
-            fetch('idpSettings.json'),
-            fetchValidateUser
-        )
+        fetchAuthorizationCodeFlowFeatureFlag()
+            .then((authorizationCodeFlowEnabled) => {
+                return initializeAuthenticationProd(
+                    dispatch,
+                    initialMatchSilentRenewCallbackUrl != null,
+                    fetch('idpSettings.json'),
+                    fetchValidateUser,
+                    authorizationCodeFlowEnabled
+                );
+            })
             .then((userManager) => {
                 setUserManager({ instance: userManager, error: null });
             })

--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -239,14 +239,18 @@ export function fetchAuthorizationCodeFlowFeatureFlag() {
     return fetch('env.json')
         .then((res) => res.json())
         .then((res) => {
-            console.log(
-                `Authorization code flow is ${
-                    res.authorizationCodeFlowFeatureFlag
-                        ? 'enabled'
-                        : 'disabled'
-                }`
-            );
-            return res.authorizationCodeFlowFeatureFlag;
+            return fetch(res.appsMetadataServerUrl + '/authentication.json')
+                .then((res) => res.json())
+                .then((res) => {
+                    console.log(
+                        `Authorization code flow is ${
+                            res.authorizationCodeFlowFeatureFlag
+                                ? 'enabled'
+                                : 'disabled'
+                        }`
+                    );
+                    return res.authorizationCodeFlowFeatureFlag;
+                });
         });
 }
 

--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -234,6 +234,22 @@ export function getExportMergeUrl(processUuid, date, format) {
     return getUrlWithToken(url);
 }
 
+export function fetchAuthorizationCodeFlowFeatureFlag() {
+    console.info(`Fetching authorization code flow feature flag...`);
+    return fetch('env.json')
+        .then((res) => res.json())
+        .then((res) => {
+            console.log(
+                `Authorization code flow is ${
+                    res.authorizationCodeFlowFeatureFlag
+                        ? 'enabled'
+                        : 'disabled'
+                }`
+            );
+            return res.authorizationCodeFlowFeatureFlag;
+        });
+}
+
 export function fetchAppsAndUrls() {
     console.info(`Fetching apps and urls...`);
     return fetch('env.json')

--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -253,7 +253,7 @@ export function fetchAuthorizationCodeFlowFeatureFlag() {
                 })
                 .catch((error) => {
                     console.error(error);
-                    console.log(
+                    console.warn(
                         `Something wrong happened when retrieving authentication.json: authorization code flow will be disabled`
                     );
                     return false;

--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -250,6 +250,13 @@ export function fetchAuthorizationCodeFlowFeatureFlag() {
                         }`
                     );
                     return res.authorizationCodeFlowFeatureFlag;
+                })
+                .catch((error) => {
+                    console.error(error);
+                    console.log(
+                        `Something wrong happened when retrieving authentication.json: authorization code flow will be disabled`
+                    );
+                    return false;
                 });
         });
 }


### PR DESCRIPTION
Add a feature flag for authorization code flow process.

If the flag authorizationCodeFlowFeatureFlag is not defined in apps-metadata it will behave as previously with implicit flow.

WARNING: this will not work until this https://github.com/gridsuite/commons-ui/pull/315 is merged, commons-ui is released and updated in this repo.

With commons-ui upgrade from 0.32.0 to 0.41.0, it required 2 new peer-dependencies: react-hook-form and yup. For webpack to build it requires these dependencies but it does not in the code, so we put it in devDependencies so  that it compiles. It will be removed by webpack tree shaking in the bundle anyway.