### PR TITLE
Resolve legacy peers

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,10 @@
             "dependencies": {
                 "@emotion/react": "^11.11.4",
                 "@emotion/styled": "^11.11.5",
-                "@gridsuite/commons-ui": "0.52.1",
+                "@gridsuite/commons-ui": "0.53.0",
                 "@mui/icons-material": "^5.15.14",
                 "@mui/lab": "5.0.0-alpha.169",
                 "@mui/material": "^5.15.14",
-                "@mui/styles": "^5.15.14",
                 "@mui/x-date-pickers": "^7.1.0",
                 "@mui/x-tree-view": "^6.17.0",
                 "@reduxjs/toolkit": "^2.2.3",
@@ -2538,6 +2537,21 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2583,6 +2597,11 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/@eslint/eslintrc/node_modules/ms": {
             "version": "2.1.2",
@@ -2729,9 +2748,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.52.1",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.52.1.tgz",
-            "integrity": "sha512-Q9CrtZJyglzMElhzLVBZHq9u3fqmnG2a4nyoV1JslREP/O2Jfk5vuNj/LXDtREoKGCZJtHimmqLI67UdLhOI3Q==",
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.53.0.tgz",
+            "integrity": "sha512-//BB1tsBxtNHINgVc3Wp3GsElr4ne2OiqFwL1Ykuf8Oq3xNyVMdds28hAKcnDrcKri+B+bsniDa3UjVvbsemUA==",
             "dependencies": {
                 "autosuggest-highlight": "^3.3.4",
                 "clsx": "^2.1.0",
@@ -2770,6 +2789,15 @@
             "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/@hookform/resolvers": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.4.tgz",
+            "integrity": "sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ==",
+            "peer": true,
+            "peerDependencies": {
+                "react-hook-form": "^7.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -3863,54 +3891,6 @@
                 "@emotion/styled": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@mui/styles": {
-            "version": "5.15.14",
-            "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.15.14.tgz",
-            "integrity": "sha512-EspFoCqLf3BadSIRM5dBqrrbE0hioI6/YZXDGzvcPsedQ7j7wAdcIs9Ex6TVqrRUADNWI/Azg6/mhcqWiBDFOg==",
-            "dependencies": {
-                "@babel/runtime": "^7.23.9",
-                "@emotion/hash": "^0.9.1",
-                "@mui/private-theming": "^5.15.14",
-                "@mui/types": "^7.2.14",
-                "@mui/utils": "^5.15.14",
-                "clsx": "^2.1.0",
-                "csstype": "^3.1.3",
-                "hoist-non-react-statics": "^3.3.2",
-                "jss": "^10.10.0",
-                "jss-plugin-camel-case": "^10.10.0",
-                "jss-plugin-default-unit": "^10.10.0",
-                "jss-plugin-global": "^10.10.0",
-                "jss-plugin-nested": "^10.10.0",
-                "jss-plugin-props-sort": "^10.10.0",
-                "jss-plugin-rule-value-function": "^10.10.0",
-                "jss-plugin-vendor-prefixer": "^10.10.0",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/styles/node_modules/clsx": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-            "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/@mui/system": {
@@ -5520,9 +5500,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5537,6 +5517,17 @@
             "dependencies": {
                 "acorn": "^7.1.1",
                 "acorn-walk": "^7.1.1"
+            }
+        },
+        "node_modules/acorn-globals/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/acorn-import-assertions": {
@@ -5616,13 +5607,13 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
             },
             "funding": {
@@ -5644,34 +5635,6 @@
                 "ajv": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "node_modules/ajv-keywords": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "peerDependencies": {
-                "ajv": "^6.9.1"
             }
         },
         "node_modules/ansi-escapes": {
@@ -6152,6 +6115,34 @@
                 "@babel/core": "^7.0.0",
                 "webpack": ">=2"
             }
+        },
+        "node_modules/babel-loader/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/babel-loader/node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/babel-loader/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/babel-loader/node_modules/schema-utils": {
             "version": "2.7.1",
@@ -7188,21 +7179,6 @@
                 }
             }
         },
-        "node_modules/css-minimizer-webpack-plugin/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/css-minimizer-webpack-plugin/node_modules/ajv-keywords": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -7213,11 +7189,6 @@
             "peerDependencies": {
                 "ajv": "^8.8.2"
             }
-        },
-        "node_modules/css-minimizer-webpack-plugin/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/css-minimizer-webpack-plugin/node_modules/schema-utils": {
             "version": "4.2.0",
@@ -7305,15 +7276,6 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/css-vendor": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-            "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.8.3",
-                "is-in-browser": "^1.0.2"
             }
         },
         "node_modules/css-what": {
@@ -8684,21 +8646,6 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/eslint-webpack-plugin/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/eslint-webpack-plugin/node_modules/ajv-keywords": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -8731,11 +8678,6 @@
                 "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
             }
         },
-        "node_modules/eslint-webpack-plugin/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
         "node_modules/eslint-webpack-plugin/node_modules/schema-utils": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
@@ -8766,6 +8708,21 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/eslint/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/eslint/node_modules/ansi-styles": {
@@ -8867,6 +8824,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/eslint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
         "node_modules/eslint/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8908,17 +8870,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/espree/node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/esprima": {
@@ -9425,6 +9376,29 @@
                 }
             }
         },
+        "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
+        },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -9506,6 +9480,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/lru-cache": {
             "version": "6.0.0",
@@ -10314,11 +10293,6 @@
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/hyphenate-style-name": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -10665,11 +10639,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/is-in-browser": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-            "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
         },
         "node_modules/is-map": {
             "version": "2.0.3",
@@ -13159,17 +13128,6 @@
                 }
             }
         },
-        "node_modules/jsdom/node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -13197,9 +13155,9 @@
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -13256,88 +13214,6 @@
             "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/jss": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-            "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "csstype": "^3.0.2",
-                "is-in-browser": "^1.1.3",
-                "tiny-warning": "^1.0.2"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/jss"
-            }
-        },
-        "node_modules/jss-plugin-camel-case": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-            "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "hyphenate-style-name": "^1.0.3",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-default-unit": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-            "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-global": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-            "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-nested": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-            "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-props-sort": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-            "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-rule-value-function": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-            "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-vendor-prefixer": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-            "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "css-vendor": "^2.0.8",
-                "jss": "10.10.0"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -13728,21 +13604,6 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/mini-css-extract-plugin/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -13753,11 +13614,6 @@
             "peerDependencies": {
                 "ajv": "^8.8.2"
             }
-        },
-        "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
             "version": "4.2.0",
@@ -14196,6 +14052,17 @@
                 "core-js": "^3.8.3",
                 "crypto-js": "^4.0.0",
                 "serialize-javascript": "^4.0.0"
+            }
+        },
+        "node_modules/oidc-client/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/on-finished": {
@@ -15998,8 +15865,7 @@
         "node_modules/property-expr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
-            "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
-            "dev": true
+            "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -16320,7 +16186,6 @@
             "version": "7.51.2",
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.2.tgz",
             "integrity": "sha512-y++lwaWjtzDt/XNnyGDQy6goHskFualmDlf+jzEZvjvz6KWDf7EboL7pUvRCzPTJd0EOPpdekYaQLEvvG6m6HA==",
-            "dev": true,
             "engines": {
                 "node": ">=12.22.0"
             },
@@ -17250,6 +17115,34 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
+        },
+        "node_modules/schema-utils/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/schema-utils/node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/schema-utils/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/select-hose": {
             "version": "2.0.0",
@@ -18465,17 +18358,6 @@
                 "randombytes": "^2.1.0"
             }
         },
-        "node_modules/terser/node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/terser/node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -18531,13 +18413,7 @@
         "node_modules/tiny-case": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
-            "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
-            "dev": true
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+            "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -18592,8 +18468,7 @@
         "node_modules/toposort": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-            "dev": true
+            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
         },
         "node_modules/tough-cookie": {
             "version": "4.1.3",
@@ -19205,21 +19080,6 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
-        "node_modules/webpack-dev-middleware/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -19230,11 +19090,6 @@
             "peerDependencies": {
                 "ajv": "^8.8.2"
             }
-        },
-        "node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
             "version": "4.2.0",
@@ -19312,21 +19167,6 @@
                 }
             }
         },
-        "node_modules/webpack-dev-server/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/webpack-dev-server/node_modules/ajv-keywords": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -19337,11 +19177,6 @@
             "peerDependencies": {
                 "ajv": "^8.8.2"
             }
-        },
-        "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/webpack-dev-server/node_modules/schema-utils": {
             "version": "4.2.0",
@@ -19422,17 +19257,6 @@
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/webpack/node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/webpack/node_modules/eslint-scope": {
@@ -19679,21 +19503,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/workbox-build/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/workbox-build/node_modules/fs-extra": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -19707,11 +19516,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/workbox-build/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/workbox-build/node_modules/source-map": {
             "version": "0.8.0-beta.0",
@@ -20095,7 +19899,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/yup/-/yup-1.4.0.tgz",
             "integrity": "sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==",
-            "dev": true,
             "dependencies": {
                 "property-expr": "^2.0.5",
                 "tiny-case": "^1.0.3",
@@ -20107,7 +19910,6 @@
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
             "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-            "dev": true,
             "engines": {
                 "node": ">=12.20"
             },

--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
     "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@gridsuite/commons-ui": "0.52.1",
+        "@gridsuite/commons-ui": "0.53.0",
         "@mui/icons-material": "^5.15.14",
         "@mui/lab": "5.0.0-alpha.169",
         "@mui/x-tree-view": "^6.17.0",
         "@mui/material": "^5.15.14",
-        "@mui/styles": "^5.15.14",
         "@mui/x-date-pickers": "^7.1.0",
         "@reduxjs/toolkit": "^2.2.3",
         "@types/node": "^20.12.2",
@@ -37,6 +36,11 @@
         "redux": "^5.0.1",
         "typeface-roboto": "^1.1.13",
         "typescript": "5.1.6"
+    },
+    "overrides": {
+        "react-scripts": {
+            "typescript": "$typescript"
+        }
     },
     "scripts": {
         "start": "PORT=3001 react-scripts start",

--- a/src/components/app-top-bar.js
+++ b/src/components/app-top-bar.js
@@ -28,7 +28,7 @@ import AppPackage from '../../package.json';
 
 export const PREFIX_URL_PROCESSES = '/processes';
 
-const classes = {
+const styles = {
     process: {
         marginLeft: 18,
     },
@@ -122,7 +122,7 @@ const AppTopBar = ({ user, userManager }) => {
                         navigate(PREFIX_URL_PROCESSES + '/' + newValue)
                     }
                     aria-label="parameters"
-                    sx={classes.process}
+                    sx={styles.process}
                 >
                     {configs.map((config) => (
                         <Tab
@@ -135,7 +135,7 @@ const AppTopBar = ({ user, userManager }) => {
                 {user && (
                     <>
                         <Button
-                            sx={classes.btnConfigurationProcesses}
+                            sx={styles.btnConfigurationProcesses}
                             onClick={() => setShowConfigurationProcesses(true)}
                         >
                             <FormattedMessage id="configureProcesses" />

--- a/src/components/app-top-bar.js
+++ b/src/components/app-top-bar.js
@@ -4,8 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useEffect, useMemo, useState } from 'react';
-import { LIGHT_THEME, logout, TopBar } from '@gridsuite/commons-ui';
+
+import { useEffect, useMemo, useState } from 'react';
+import { logout, TopBar } from '@gridsuite/commons-ui';
 import Parameters, { useParameterState } from './parameters';
 import { PARAM_LANGUAGE, PARAM_THEME } from '../utils/config-params';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,37 +17,34 @@ import {
     getServersInfos,
 } from '../utils/rest-api';
 import PropTypes from 'prop-types';
-import { useNavigate, useMatch } from 'react-router-dom';
+import { useMatch, useNavigate } from 'react-router-dom';
 import { ReactComponent as GridMergeLogoLight } from '../images/GridMerge_logo_light.svg';
 import { ReactComponent as GridMergeLogoDark } from '../images/GridMerge_logo_dark.svg';
-import { Tabs, Tab, Button } from '@mui/material';
+import { Button, Tab, Tabs, useTheme } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import ProcessesConfigurationDialog from './processes-configuration-dialog';
-import { makeStyles } from '@mui/styles';
 import { initProcesses } from '../redux/actions';
 import AppPackage from '../../package.json';
 
 export const PREFIX_URL_PROCESSES = '/processes';
 
-const useStyles = makeStyles(() => ({
+const classes = {
     process: {
         marginLeft: 18,
     },
     btnConfigurationProcesses: {
         marginLeft: 'auto',
     },
-}));
+};
 
 const AppTopBar = ({ user, userManager }) => {
     const navigate = useNavigate();
 
     const dispatch = useDispatch();
 
-    const classes = useStyles();
-
     const [appsAndUrls, setAppsAndUrls] = useState([]);
 
-    const theme = useSelector((state) => state[PARAM_THEME]);
+    const theme = useTheme();
 
     const configs = useSelector((state) => state.configs);
 
@@ -93,7 +91,7 @@ const AppTopBar = ({ user, userManager }) => {
                 appName="Merge"
                 appColor="#4795D1"
                 appLogo={
-                    theme === LIGHT_THEME ? (
+                    theme.palette.mode === 'light' ? (
                         <GridMergeLogoLight />
                     ) : (
                         <GridMergeLogoDark />
@@ -124,7 +122,7 @@ const AppTopBar = ({ user, userManager }) => {
                         navigate(PREFIX_URL_PROCESSES + '/' + newValue)
                     }
                     aria-label="parameters"
-                    className={classes.process}
+                    sx={classes.process}
                 >
                     {configs.map((config) => (
                         <Tab
@@ -137,7 +135,7 @@ const AppTopBar = ({ user, userManager }) => {
                 {user && (
                     <>
                         <Button
-                            className={classes.btnConfigurationProcesses}
+                            sx={classes.btnConfigurationProcesses}
                             onClick={() => setShowConfigurationProcesses(true)}
                         >
                             <FormattedMessage id="configureProcesses" />

--- a/src/components/country-state-item.js
+++ b/src/components/country-state-item.js
@@ -4,17 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
+
 import { Box, Divider, Grid, Typography } from '@mui/material';
 import LensIcon from '@mui/icons-material/Lens';
 import PropTypes from 'prop-types';
-import makeStyles from '@mui/styles/makeStyles';
 import { getIgmStatus, MergeType } from '../utils/rest-api';
 import { getDetailsByCountryOrTso } from '../utils/tso-country-details';
 import { tsoColor } from './merge-map';
 import { useIntl } from 'react-intl';
 
-const useStyles = makeStyles((theme) => ({
+const classes = {
     tsosColumn: {
         flexGrow: 1,
         width: 80,
@@ -31,18 +30,17 @@ const useStyles = makeStyles((theme) => ({
         width: 32,
         marginTop: 8,
     },
-    listItem: {
+    listItem: (theme) => ({
         backgroundColor: theme.palette.background.paper,
-    },
+    }),
     divider: {
         marginTop: 4,
         color: '#ECF5FD',
     },
-    smallText: theme.typography.caption,
-}));
+    smallText: (theme) => theme.typography.caption,
+};
 
 const CountryStateItem = (props) => {
-    const classes = useStyles();
     const intl = useIntl();
 
     const detail = getDetailsByCountryOrTso(props.tso.toUpperCase());
@@ -57,42 +55,33 @@ const CountryStateItem = (props) => {
         replacedWith += new Date(status.replacingDate).toLocaleString();
     }
     return (
-        <Box className={classes.listItem}>
+        <Box sx={classes.listItem}>
             <Grid container>
                 <Grid
                     item
                     xs={12}
                     style={{ display: 'flex', width: '100%', padding: 8 }}
                 >
-                    <LensIcon
-                        className={classes.stateIcon}
-                        style={{ color: color }}
-                    />
-                    <Box className={classes.tsosColumn}>
+                    <LensIcon sx={classes.stateIcon} style={{ color: color }} />
+                    <Box sx={classes.tsosColumn}>
                         <Typography variant="body1">{props.tso}</Typography>
                         <Typography variant="caption">
                             {detail.countryName}
                         </Typography>
                     </Box>
                     {replacedWith && (
-                        <Box className={classes.textReplace}>
-                            <Typography
-                                variant="body1"
-                                className={classes.smallText}
-                            >
+                        <Box sx={classes.textReplace}>
+                            <Typography variant="body1" sx={classes.smallText}>
                                 {intl.formatMessage({ id: 'ReplacedWith' })}
                             </Typography>
-                            <Typography
-                                variant="body1"
-                                className={classes.smallText}
-                            >
+                            <Typography variant="body1" sx={classes.smallText}>
                                 {replacedWith}
                             </Typography>
                         </Box>
                     )}
                 </Grid>
                 <Grid item xs={12}>
-                    <Divider className={classes.divider} />
+                    <Divider sx={classes.divider} />
                 </Grid>
             </Grid>
         </Box>

--- a/src/components/country-state-item.js
+++ b/src/components/country-state-item.js
@@ -13,7 +13,7 @@ import { getDetailsByCountryOrTso } from '../utils/tso-country-details';
 import { tsoColor } from './merge-map';
 import { useIntl } from 'react-intl';
 
-const classes = {
+const styles = {
     tsosColumn: {
         flexGrow: 1,
         width: 80,
@@ -55,33 +55,33 @@ const CountryStateItem = (props) => {
         replacedWith += new Date(status.replacingDate).toLocaleString();
     }
     return (
-        <Box sx={classes.listItem}>
+        <Box sx={styles.listItem}>
             <Grid container>
                 <Grid
                     item
                     xs={12}
                     style={{ display: 'flex', width: '100%', padding: 8 }}
                 >
-                    <LensIcon sx={classes.stateIcon} style={{ color: color }} />
-                    <Box sx={classes.tsosColumn}>
+                    <LensIcon sx={styles.stateIcon} style={{ color: color }} />
+                    <Box sx={styles.tsosColumn}>
                         <Typography variant="body1">{props.tso}</Typography>
                         <Typography variant="caption">
                             {detail.countryName}
                         </Typography>
                     </Box>
                     {replacedWith && (
-                        <Box sx={classes.textReplace}>
-                            <Typography variant="body1" sx={classes.smallText}>
+                        <Box sx={styles.textReplace}>
+                            <Typography variant="body1" sx={styles.smallText}>
                                 {intl.formatMessage({ id: 'ReplacedWith' })}
                             </Typography>
-                            <Typography variant="body1" sx={classes.smallText}>
+                            <Typography variant="body1" sx={styles.smallText}>
                                 {replacedWith}
                             </Typography>
                         </Box>
                     )}
                 </Grid>
                 <Grid item xs={12}>
-                    <Divider sx={classes.divider} />
+                    <Divider sx={styles.divider} />
                 </Grid>
             </Grid>
         </Box>

--- a/src/components/merge-map.css
+++ b/src/components/merge-map.css
@@ -1,0 +1,5 @@
+.tso {
+    stroke: white;
+    stroke-width: 1px;
+    vector-effect: non-scaling-stroke;
+}

--- a/src/components/merge-map.css
+++ b/src/components/merge-map.css
@@ -1,5 +1,0 @@
-.tso {
-    stroke: white;
-    stroke-width: 1px;
-    vector-effect: non-scaling-stroke;
-}

--- a/src/components/merge-map.js
+++ b/src/components/merge-map.js
@@ -7,7 +7,12 @@
 
 import { memo, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
+import styled from '@emotion/styled';
+import {
+    ComposableMap,
+    Geographies,
+    Geography as RawGeography,
+} from 'react-simple-maps';
 import bbox from 'geojson-bbox';
 import {
     CgmStatus,
@@ -17,7 +22,12 @@ import {
 } from '../utils/rest-api';
 import { Tooltip } from 'react-tooltip';
 import { getDetailsByCountryOrTso } from '../utils/tso-country-details';
-import './merge-map.css';
+
+const Geography = styled(RawGeography)`
+    stroke: white;
+    stroke-width: 1px;
+    vector-effect: non-scaling-stroke;
+`;
 
 const DEFAULT_CENTER = [0, 0];
 const DEFAULT_SCALE = 35000;

--- a/src/components/merge-map.js
+++ b/src/components/merge-map.js
@@ -7,7 +7,7 @@
 
 import { memo, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
+import { styled } from '@mui/material';
 import {
     ComposableMap,
     Geographies,
@@ -23,11 +23,11 @@ import {
 import { Tooltip } from 'react-tooltip';
 import { getDetailsByCountryOrTso } from '../utils/tso-country-details';
 
-const Geography = styled(RawGeography)`
-    stroke: white;
-    stroke-width: 1px;
-    vector-effect: non-scaling-stroke;
-`;
+const Geography = styled(RawGeography)({
+    stroke: 'white',
+    strokeWidth: '1px',
+    vectorEffect: 'non-scaling-stroke',
+});
 
 const DEFAULT_CENTER = [0, 0];
 const DEFAULT_SCALE = 35000;

--- a/src/components/merge-map.js
+++ b/src/components/merge-map.js
@@ -5,32 +5,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
-
-import makeStyles from '@mui/styles/makeStyles';
 import bbox from 'geojson-bbox';
 import {
-    IgmStatus,
-    getIgmStatus,
-    MergeType,
     CgmStatus,
+    getIgmStatus,
+    IgmStatus,
+    MergeType,
 } from '../utils/rest-api';
 import { Tooltip } from 'react-tooltip';
 import { getDetailsByCountryOrTso } from '../utils/tso-country-details';
+import './merge-map.css';
 
-const TSO_STROKE_COLOR = 'white';
 const DEFAULT_CENTER = [0, 0];
 const DEFAULT_SCALE = 35000;
-
-const useStyles = makeStyles((theme) => ({
-    tso: {
-        stroke: TSO_STROKE_COLOR,
-        strokeWidth: '1px',
-        vectorEffect: 'non-scaling-stroke',
-    },
-}));
 
 const LIGHT_BLUE_COLOR = '#009CD8';
 const LIGHT_YELLOW_COLOR = '#F8E67E';
@@ -90,8 +80,6 @@ const MergeMap = (props) => {
     });
 
     const [tooltip, setTooltip] = useState('');
-
-    const classes = useStyles();
 
     function computeBoundingBox(geoJsons) {
         const reducer = (oldBb, json) => {
@@ -170,7 +158,7 @@ const MergeMap = (props) => {
                                 <Geography
                                     key={geo.rsmKey}
                                     geography={geo}
-                                    className={classes.tso}
+                                    className="tso"
                                     fill={color}
                                     onMouseEnter={() => {
                                         if (
@@ -235,4 +223,4 @@ MergeMap.propTypes = {
     config: PropTypes.object,
 };
 
-export default React.memo(MergeMap);
+export default memo(MergeMap);

--- a/src/components/parameters.js
+++ b/src/components/parameters.js
@@ -5,12 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
-
+import { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-
 import { useSelector } from 'react-redux';
-
 import {
     Box,
     Button,
@@ -19,26 +16,23 @@ import {
     DialogContent,
     DialogTitle,
     Grid,
+    Switch,
     Tab,
     Tabs,
     Typography,
-    Switch,
 } from '@mui/material';
-
-import makeStyles from '@mui/styles/makeStyles';
-
 import { updateConfigParameter } from '../utils/rest-api';
 import { PARAM_TIMELINE_DIAGONAL_LABELS } from '../utils/config-params';
 import { useSnackMessage } from '@gridsuite/commons-ui';
 
-const useStyles = makeStyles((theme) => ({
+const classes = {
     controlItem: {
         justifyContent: 'flex-end',
     },
     button: {
         marginBottom: '30px',
     },
-}));
+};
 
 export function useParameterState(paramName) {
     const { snackError } = useSnackMessage();
@@ -68,57 +62,55 @@ export function useParameterState(paramName) {
     return [paramLocalState, handleChangeParamLocalState];
 }
 
-const Parameters = ({ showParameters, hideParameters }) => {
-    const classes = useStyles();
+function TabPanel(props) {
+    const { children, value, index, ...other } = props;
 
-    const [tabIndex, setTabIndex] = useState(0);
+    return (
+        <Typography
+            component="div"
+            role="tabpanel"
+            hidden={value !== index}
+            id={`simple-tabpanel-${index}`}
+            aria-labelledby={`simple-tab-${index}`}
+            {...other}
+        >
+            {value === index && <Box p={3}>{children}</Box>}
+        </Typography>
+    );
+}
 
+function GUITab() {
     const [timelineDiagonalLabelLocal, handleChangeTimelineDiagonalLabelLocal] =
         useParameterState(PARAM_TIMELINE_DIAGONAL_LABELS);
 
-    function TabPanel(props) {
-        const { children, value, index, ...other } = props;
-
-        return (
-            <Typography
-                component="div"
-                role="tabpanel"
-                hidden={value !== index}
-                id={`simple-tabpanel-${index}`}
-                aria-labelledby={`simple-tab-${index}`}
-                {...other}
-            >
-                {value === index && <Box p={3}>{children}</Box>}
-            </Typography>
-        );
-    }
-
-    function GUITab() {
-        return (
-            <Grid container spacing={2} className={classes.grid}>
-                <Grid item xs={8}>
-                    <Typography component="span" variant="body1">
-                        <Box fontWeight="fontWeightBold" m={1}>
-                            <FormattedMessage id="timelineDiagonalLabels" />
-                        </Box>
-                    </Typography>
-                </Grid>
-                <Grid item container xs={4} className={classes.controlItem}>
-                    <Switch
-                        checked={timelineDiagonalLabelLocal}
-                        onChange={(event) => {
-                            handleChangeTimelineDiagonalLabelLocal(
-                                event.target.value !== 'true'
-                            );
-                        }}
-                        value={timelineDiagonalLabelLocal}
-                        color="primary"
-                        inputProps={{ 'aria-label': 'primary checkbox' }}
-                    />
-                </Grid>
+    return (
+        <Grid container spacing={2} sx={classes.grid}>
+            <Grid item xs={8}>
+                <Typography component="span" variant="body1">
+                    <Box fontWeight="fontWeightBold" m={1}>
+                        <FormattedMessage id="timelineDiagonalLabels" />
+                    </Box>
+                </Typography>
             </Grid>
-        );
-    }
+            <Grid item container xs={4} sx={classes.controlItem}>
+                <Switch
+                    checked={timelineDiagonalLabelLocal}
+                    onChange={(event) => {
+                        handleChangeTimelineDiagonalLabelLocal(
+                            event.target.value !== 'true'
+                        );
+                    }}
+                    value={timelineDiagonalLabelLocal}
+                    color="primary"
+                    inputProps={{ 'aria-label': 'primary checkbox' }}
+                />
+            </Grid>
+        </Grid>
+    );
+}
+
+const Parameters = ({ showParameters, hideParameters }) => {
+    const [tabIndex, setTabIndex] = useState(0);
 
     return (
         <Dialog
@@ -129,11 +121,7 @@ const Parameters = ({ showParameters, hideParameters }) => {
             fullWidth={true}
         >
             <DialogTitle id="form-dialog-title">
-                <Typography
-                    component="span"
-                    variant="h5"
-                    className={classes.title}
-                >
+                <Typography component="span" variant="h5" sx={classes.title}>
                     <FormattedMessage id="parameters" />
                 </Typography>
             </DialogTitle>
@@ -159,7 +147,7 @@ const Parameters = ({ showParameters, hideParameters }) => {
                             onClick={hideParameters}
                             variant="contained"
                             color="primary"
-                            className={classes.button}
+                            sx={classes.button}
                         >
                             <FormattedMessage id="close" />
                         </Button>

--- a/src/components/parameters.js
+++ b/src/components/parameters.js
@@ -25,7 +25,7 @@ import { updateConfigParameter } from '../utils/rest-api';
 import { PARAM_TIMELINE_DIAGONAL_LABELS } from '../utils/config-params';
 import { useSnackMessage } from '@gridsuite/commons-ui';
 
-const classes = {
+const styles = {
     controlItem: {
         justifyContent: 'flex-end',
     },
@@ -84,7 +84,7 @@ function GUITab() {
         useParameterState(PARAM_TIMELINE_DIAGONAL_LABELS);
 
     return (
-        <Grid container spacing={2} sx={classes.grid}>
+        <Grid container spacing={2} sx={styles.grid}>
             <Grid item xs={8}>
                 <Typography component="span" variant="body1">
                     <Box fontWeight="fontWeightBold" m={1}>
@@ -92,7 +92,7 @@ function GUITab() {
                     </Box>
                 </Typography>
             </Grid>
-            <Grid item container xs={4} sx={classes.controlItem}>
+            <Grid item container xs={4} sx={styles.controlItem}>
                 <Switch
                     checked={timelineDiagonalLabelLocal}
                     onChange={(event) => {
@@ -121,7 +121,7 @@ const Parameters = ({ showParameters, hideParameters }) => {
             fullWidth={true}
         >
             <DialogTitle id="form-dialog-title">
-                <Typography component="span" variant="h5" sx={classes.title}>
+                <Typography component="span" variant="h5" sx={styles.title}>
                     <FormattedMessage id="parameters" />
                 </Typography>
             </DialogTitle>
@@ -147,7 +147,7 @@ const Parameters = ({ showParameters, hideParameters }) => {
                             onClick={hideParameters}
                             variant="contained"
                             color="primary"
-                            sx={classes.button}
+                            sx={styles.button}
                         >
                             <FormattedMessage id="close" />
                         </Button>

--- a/src/components/process.js
+++ b/src/components/process.js
@@ -5,12 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect } from 'react';
-
+import { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
-
 import { useDispatch, useSelector } from 'react-redux';
-
 import MergeMap from './merge-map';
 import {
     connectNotificationsWebsocket,
@@ -26,23 +23,18 @@ import { store } from '../redux/store';
 import Timeline from './timeline';
 import StepperWithStatus from './stepper';
 import CountryStatesList from './country-state-list';
-import { Grid, Chip } from '@mui/material';
-
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { Chip, Grid } from '@mui/material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
-import { LocalizationProvider } from '@mui/x-date-pickers';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { useSnackbar } from 'notistack';
-import makeStyles from '@mui/styles/makeStyles';
 
-const useStyles = makeStyles((theme) => ({
+const classes = {
     itemBusinessProcess: {
         margin: '20px',
     },
-}));
+};
 
 const Process = (props) => {
-    const classes = useStyles();
-
     const config = useSelector((state) => state.configs[props.index]);
 
     const date = useSelector((state) => state.processes[props.index].date);
@@ -181,7 +173,7 @@ const Process = (props) => {
                         xs={12}
                         md={2}
                         key="businessProcess"
-                        className={classes.itemBusinessProcess}
+                        sx={classes.itemBusinessProcess}
                     >
                         <Chip label={config.businessProcess} />
                     </Grid>

--- a/src/components/process.js
+++ b/src/components/process.js
@@ -28,7 +28,7 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { useSnackbar } from 'notistack';
 
-const classes = {
+const styles = {
     itemBusinessProcess: {
         margin: '20px',
     },
@@ -173,7 +173,7 @@ const Process = (props) => {
                         xs={12}
                         md={2}
                         key="businessProcess"
-                        sx={classes.itemBusinessProcess}
+                        sx={styles.itemBusinessProcess}
                     >
                         <Chip label={config.businessProcess} />
                     </Grid>

--- a/src/components/processes-configuration-dialog.js
+++ b/src/components/processes-configuration-dialog.js
@@ -20,7 +20,6 @@ import {
     RadioGroup,
     TextField,
     Typography,
-    withStyles,
 } from '@mui/material';
 import {
     AddCircle as AddCircleIcon,
@@ -41,7 +40,7 @@ import { initProcesses } from '../redux/actions';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-const classes = {
+const styles = {
     addNewTso: (theme) => ({
         border: '1px solid',
         padding: theme.spacing(1),
@@ -53,31 +52,29 @@ const classes = {
     input: {
         textOverflow: 'ellipsis',
     },
-};
 
-const styles = () => ({
     // Link : https://material-ui.com/components/dialogs/#customized-dialogs
     // Material ui recommends position:absolute for the close button but we prefer display:flex  instead
-    root: {
+    dialogTitle: {
         display: 'flex',
     },
     closeButton: {
         marginLeft: 'auto',
         padding: 0,
     },
-});
+};
 
-const CustomDialogTitle = withStyles(styles)((props) => {
-    const { children, classes, onClose, ...other } = props;
+const CustomDialogTitle = (props) => {
+    const { children, onClose, ...other } = props;
     return (
-        <DialogTitle sx={classes.root} {...other}>
+        <DialogTitle sx={styles.dialogTitle} {...other}>
             <Typography variant="h6" component="span">
                 {children}
             </Typography>
             {onClose && (
                 <IconButton
                     aria-label="close"
-                    sx={classes.closeButton}
+                    sx={styles.closeButton}
                     onClick={onClose}
                 >
                     <CloseIcon />
@@ -85,7 +82,7 @@ const CustomDialogTitle = withStyles(styles)((props) => {
             )}
         </DialogTitle>
     );
-});
+};
 
 const keyGenerator = (() => {
     let key = 1;
@@ -401,7 +398,7 @@ const ProcessesContainer = ({ handleProcessesChanged, currentProcess }) => {
 
     return (
         <div>
-            <Grid container sx={classes.newTsoContainerLabel}>
+            <Grid container sx={styles.newTsoContainerLabel}>
                 <Grid item xs={12} sm={7}>
                     <FormattedMessage id="processes" />
                 </Grid>
@@ -413,7 +410,7 @@ const ProcessesContainer = ({ handleProcessesChanged, currentProcess }) => {
                 <Grid
                     container
                     spacing={1}
-                    sx={classes.addNewTso}
+                    sx={styles.addNewTso}
                     key={process.processUuid}
                 >
                     {/* Process input*/}
@@ -426,7 +423,7 @@ const ProcessesContainer = ({ handleProcessesChanged, currentProcess }) => {
                                 })}
                                 value={process.process}
                                 InputProps={{
-                                    classes: { input: classes.input },
+                                    classes: { input: styles.input },
                                 }}
                                 onChange={(e) =>
                                     handleProcessNameChanged(e, index)

--- a/src/components/processes-configuration-dialog.js
+++ b/src/components/processes-configuration-dialog.js
@@ -5,57 +5,55 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
-
+import { useCallback, useEffect, useState } from 'react';
 import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
-    Typography,
-    IconButton,
+    Autocomplete,
     Button,
-    TextField,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    FormControlLabel,
     Grid,
+    IconButton,
+    Radio,
+    RadioGroup,
+    TextField,
+    Typography,
+    withStyles,
 } from '@mui/material';
-
-import CloseIcon from '@mui/icons-material/Close';
-import DeleteIcon from '@mui/icons-material/Delete';
-import AddCircleIcon from '@mui/icons-material/AddCircle';
+import {
+    AddCircle as AddCircleIcon,
+    Close as CloseIcon,
+    Delete as DeleteIcon,
+} from '@mui/icons-material';
 import { FormattedMessage, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-
-import makeStyles from '@mui/styles/makeStyles';
-import withStyles from '@mui/styles/withStyles';
 import {
     createProcess,
     deleteProcess,
+    fetchBoundariesList,
+    fetchBusinessProcessesList,
     fetchMergeConfigs,
     fetchTsosList,
-    fetchBusinessProcessesList,
-    fetchBoundariesList,
 } from '../utils/rest-api';
 import { initProcesses } from '../redux/actions';
 import { useDispatch, useSelector } from 'react-redux';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Radio from '@mui/material/Radio';
 import { useNavigate } from 'react-router-dom';
-import Autocomplete from '@mui/material/Autocomplete';
 
-const useStyles = makeStyles((theme) => ({
-    addNewTso: {
+const classes = {
+    addNewTso: (theme) => ({
         border: '1px solid',
         padding: theme.spacing(1),
         margin: theme.spacing(2, 0, 2, 0),
-    },
+    }),
     newTsoContainerLabel: {
         fontWeight: 'bold',
     },
     input: {
         textOverflow: 'ellipsis',
     },
-}));
+};
 
 const styles = () => ({
     // Link : https://material-ui.com/components/dialogs/#customized-dialogs
@@ -72,14 +70,14 @@ const styles = () => ({
 const CustomDialogTitle = withStyles(styles)((props) => {
     const { children, classes, onClose, ...other } = props;
     return (
-        <DialogTitle className={classes.root} {...other}>
+        <DialogTitle sx={classes.root} {...other}>
             <Typography variant="h6" component="span">
                 {children}
             </Typography>
             {onClose && (
                 <IconButton
                     aria-label="close"
-                    className={classes.closeButton}
+                    sx={classes.closeButton}
                     onClick={onClose}
                 >
                     <CloseIcon />
@@ -298,7 +296,6 @@ const ProcessBoundarySet = ({
 };
 
 const ProcessesContainer = ({ handleProcessesChanged, currentProcess }) => {
-    const classes = useStyles();
     const intl = useIntl();
 
     const [authorizedTsosCodes, setAuthorizedTsosCodes] = useState([]);
@@ -404,7 +401,7 @@ const ProcessesContainer = ({ handleProcessesChanged, currentProcess }) => {
 
     return (
         <div>
-            <Grid container className={classes.newTsoContainerLabel}>
+            <Grid container sx={classes.newTsoContainerLabel}>
                 <Grid item xs={12} sm={7}>
                     <FormattedMessage id="processes" />
                 </Grid>
@@ -416,7 +413,7 @@ const ProcessesContainer = ({ handleProcessesChanged, currentProcess }) => {
                 <Grid
                     container
                     spacing={1}
-                    className={classes.addNewTso}
+                    sx={classes.addNewTso}
                     key={process.processUuid}
                 >
                     {/* Process input*/}
@@ -723,50 +720,43 @@ const ProcessesConfigurationDialog = ({ open, onClose, matchProcess }) => {
     };
 
     return (
-        <>
-            <Dialog
-                open={open}
-                onClose={cancel}
-                maxWidth={'lg'}
-                fullWidth={true}
-            >
-                <CustomDialogTitle id="form-dialog-title" onClose={cancel}>
-                    {confirmSave ? (
-                        <FormattedMessage id="deletionProcessesTitle" />
-                    ) : (
-                        <FormattedMessage id="mergingProcessConfigurationTitle" />
-                    )}
-                </CustomDialogTitle>
-                <DialogContent dividers>
-                    {confirmSave ? (
-                        <h3>
-                            <FormattedMessage id="confirmMessage" />
-                        </h3>
-                    ) : (
-                        <ProcessesContainer
-                            currentProcess={processes}
-                            handleProcessesChanged={handleProcessesChanged}
-                        />
-                    )}
-                    {confirmSave &&
-                        processesToBeDeleted().map((e) => (
-                            <h3 key={e.processUuid}>{e.process}</h3>
-                        ))}
-                </DialogContent>
-                <DialogActions>
-                    <Button autoFocus size="small" onClick={cancel}>
-                        <FormattedMessage id="cancel" />
-                    </Button>
-                    <Button
-                        variant="outlined"
-                        size="small"
-                        onClick={confirmSave ? handleSave : saveButtonClicked}
-                    >
-                        <FormattedMessage id="confirm" />
-                    </Button>
-                </DialogActions>
-            </Dialog>
-        </>
+        <Dialog open={open} onClose={cancel} maxWidth="lg" fullWidth={true}>
+            <CustomDialogTitle id="form-dialog-title" onClose={cancel}>
+                {confirmSave ? (
+                    <FormattedMessage id="deletionProcessesTitle" />
+                ) : (
+                    <FormattedMessage id="mergingProcessConfigurationTitle" />
+                )}
+            </CustomDialogTitle>
+            <DialogContent dividers>
+                {confirmSave ? (
+                    <h3>
+                        <FormattedMessage id="confirmMessage" />
+                    </h3>
+                ) : (
+                    <ProcessesContainer
+                        currentProcess={processes}
+                        handleProcessesChanged={handleProcessesChanged}
+                    />
+                )}
+                {confirmSave &&
+                    processesToBeDeleted().map((e) => (
+                        <h3 key={e.processUuid}>{e.process}</h3>
+                    ))}
+            </DialogContent>
+            <DialogActions>
+                <Button autoFocus size="small" onClick={cancel}>
+                    <FormattedMessage id="cancel" />
+                </Button>
+                <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={confirmSave ? handleSave : saveButtonClicked}
+                >
+                    <FormattedMessage id="confirm" />
+                </Button>
+            </DialogActions>
+        </Dialog>
     );
 };
 

--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -24,7 +24,13 @@ import {
 } from '../utils/rest-api';
 import PropTypes from 'prop-types';
 
-const classes = {
+const baseStyles = {
+    stepperGridMargins: {
+        marginLeft: '2px',
+        marginRight: '2px',
+    },
+};
+const styles = {
     stepper: {
         '& .MuiStepper-root': {
             padding: '30px 15px 25px 15px',
@@ -34,10 +40,12 @@ const classes = {
         position: 'absolute',
         bottom: '15px',
     },
-    stepperGridMargins: {
-        marginLeft: '2px',
-        marginRight: '2px',
-    },
+    stepperGridMargins: baseStyles.stepperGridMargins,
+    stepperButtonContainer: (theme) => ({
+        ...baseStyles.stepperGridMargins,
+        textAlign: 'center',
+        backgroundColor: theme.palette.background.paper,
+    }),
     stepperButton: {
         padding: '3px',
     },
@@ -72,13 +80,6 @@ const classes = {
         [theme.breakpoints.down('sm')]: {
             minHeight: '120px',
         },
-    }),
-};
-const classes2 = {
-    stepperButtonContainer: (theme) => ({
-        ...classes.stepperGridMargins,
-        textAlign: 'center',
-        backgroundColor: theme.palette.background.paper,
     }),
 };
 
@@ -209,83 +210,80 @@ const StepperWithStatus = (props) => {
     }, [stepper]);
 
     return (
-        <Grid container direction="row" sx={classes.stepperGridContainer}>
+        <Grid container direction="row" sx={styles.stepperGridContainer}>
             <Grid item xs={12} md={2} />
-            <Grid item xs={12} md={1} sx={classes2.stepperButtonContainer}>
+            <Grid item xs={12} md={1} sx={styles.stepperButtonContainer}>
                 <IconButton
                     aria-label="replace"
-                    sx={classes.stepperButton}
+                    sx={styles.stepperButton}
                     onClick={handleReplaceIGM}
                     disabled={!replaceIGMEnabled}
                 >
-                    <BuildIcon
-                        fontSize="large"
-                        sx={classes.stepperButtonIcon}
-                    />
+                    <BuildIcon fontSize="large" sx={styles.stepperButtonIcon} />
                 </IconButton>
                 <Box
                     component="span"
                     sx={
                         replaceIGMEnabled
-                            ? classes.buttonLabelEnabled
-                            : classes.buttonLabelDisabled
+                            ? styles.buttonLabelEnabled
+                            : styles.buttonLabelDisabled
                     }
                 >
                     <FormattedMessage id="replaceIGM" />
                 </Box>
             </Grid>
-            <Grid item xs={12} md={5} sx={classes.stepperGridMargins}>
-                <Stepper sx={classes.stepper}>
+            <Grid item xs={12} md={5} sx={styles.stepperGridMargins}>
+                <Stepper sx={styles.stepper}>
                     <Step active={availableStep}>
-                        <StepLabel sx={classes.stepLabel}>
+                        <StepLabel sx={styles.stepLabel}>
                             <FormattedMessage id="igmReception" />
                         </StepLabel>
                     </Step>
                     <Step active={validStep}>
-                        <StepLabel sx={classes.stepLabel}>
+                        <StepLabel sx={styles.stepLabel}>
                             <FormattedMessage id="imgMerged" />
                         </StepLabel>
                     </Step>
                     <Step active={mergedStep}>
-                        <StepLabel sx={classes.stepLabel}>
+                        <StepLabel sx={styles.stepLabel}>
                             <FormattedMessage id="cgmValid" />
                         </StepLabel>
                     </Step>
                 </Stepper>
             </Grid>
-            <Grid item xs={12} md={1} sx={classes2.stepperButtonContainer}>
+            <Grid item xs={12} md={1} sx={styles.stepperButtonContainer}>
                 <IconButton
                     aria-label="report"
-                    sx={classes.stepperButton}
+                    sx={styles.stepperButton}
                     onClick={handleClickShowReport}
                     disabled={!mergedStep}
                 >
                     <AccountTreeIcon
                         fontSize="large"
-                        sx={classes.stepperButtonIcon}
+                        sx={styles.stepperButtonIcon}
                     />
                 </IconButton>
                 <Box
                     component="span"
                     sx={
                         mergedStep
-                            ? classes.buttonLabelEnabled
-                            : classes.buttonLabelDisabled
+                            ? styles.buttonLabelEnabled
+                            : styles.buttonLabelDisabled
                     }
                 >
                     <FormattedMessage id="showReport" />
                 </Box>
             </Grid>
-            <Grid item xs={12} md={1} sx={classes2.stepperButtonContainer}>
+            <Grid item xs={12} md={1} sx={styles.stepperButtonContainer}>
                 <IconButton
                     aria-label="download"
-                    sx={classes.stepperButton}
+                    sx={styles.stepperButton}
                     onClick={handleOpenExport}
                     disabled={!mergedStep}
                 >
                     <GetAppIcon
                         fontSize="large"
-                        sx={classes.stepperButtonIcon}
+                        sx={styles.stepperButtonIcon}
                     />
                 </IconButton>
                 <Box
@@ -293,14 +291,14 @@ const StepperWithStatus = (props) => {
                     title="download"
                     id={DownloadIframe}
                     name={DownloadIframe}
-                    sx={classes.iframe}
+                    sx={styles.iframe}
                 />
                 <Box
                     component="span"
                     sx={
                         mergedStep
-                            ? classes.buttonLabelEnabled
-                            : classes.buttonLabelDisabled
+                            ? styles.buttonLabelEnabled
+                            : styles.buttonLabelDisabled
                     }
                 >
                     <FormattedMessage id="downloadCgm" />

--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -4,15 +4,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useCallback, useEffect, useState } from 'react';
-
-import { makeStyles, withStyles } from '@mui/styles';
-import { Stepper, Step, StepLabel, IconButton, Grid } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { Box, Grid, IconButton, Step, StepLabel, Stepper } from '@mui/material';
 import { FormattedMessage, useIntl } from 'react-intl';
-import GetAppIcon from '@mui/icons-material/GetApp';
-import AccountTreeIcon from '@mui/icons-material/AccountTree';
-import BuildIcon from '@mui/icons-material/Build';
-import { ReportViewerDialog } from '@gridsuite/commons-ui';
+import {
+    AccountTree as AccountTreeIcon,
+    Build as BuildIcon,
+    GetApp as GetAppIcon,
+} from '@mui/icons-material';
+import { ReportViewerDialog, useSnackMessage } from '@gridsuite/commons-ui';
 import { ExportDialog } from '../utils/dialogs';
 import {
     CgmStatus,
@@ -23,9 +23,13 @@ import {
     replaceIGM,
 } from '../utils/rest-api';
 import PropTypes from 'prop-types';
-import { useSnackMessage } from '@gridsuite/commons-ui';
 
-const useStyles = makeStyles((theme) => ({
+const classes = {
+    stepper: {
+        '& .MuiStepper-root': {
+            padding: '30px 15px 25px 15px',
+        },
+    },
     stepperGridContainer: {
         position: 'absolute',
         bottom: '15px',
@@ -33,10 +37,6 @@ const useStyles = makeStyles((theme) => ({
     stepperGridMargins: {
         marginLeft: '2px',
         marginRight: '2px',
-    },
-    stepperButtonContainer: {
-        textAlign: 'center',
-        backgroundColor: theme.palette.background.paper,
     },
     stepperButton: {
         padding: '3px',
@@ -63,43 +63,39 @@ const useStyles = makeStyles((theme) => ({
         width: 0,
         height: 0,
     },
-    [theme.breakpoints.down('xs') && theme.breakpoints.down('sm')]: {
-        downloadContainer: {
+    downloadContainer: (theme) => ({
+        [theme.breakpoints.down('sm')]: {
             minHeight: '120px',
         },
-        replaceIGMContainer: {
+    }),
+    replaceIGMContainer: (theme) => ({
+        [theme.breakpoints.down('sm')]: {
             minHeight: '120px',
         },
-    },
-}));
-
-const CustomStepper = withStyles({
-    root: {
-        padding: '30px 15px 25px 15px',
-    },
-})(Stepper);
-
-const CustomStepLabel = withStyles({
-    label: {
-        fontSize: '16px',
-    },
-})(StepLabel);
+    }),
+};
+const classes2 = {
+    stepperButtonContainer: (theme) => ({
+        ...classes.stepperGridMargins,
+        textAlign: 'center',
+        backgroundColor: theme.palette.background.paper,
+    }),
+};
 
 const StepperWithStatus = (props) => {
     const intl = useIntl();
     const DownloadIframe = 'downloadIframe';
     const availableFormats = ['CGMES', 'XIIDM'];
-    const classes = useStyles();
     const [availableStep, setAvailableStep] = useState(false);
     const [validStep, setValidStep] = useState(false);
     const [mergedStep, setMergedStep] = useState(false);
     const [replaceIGMEnabled, setReplaceIGMEnabled] = useState(false);
     const { snackError, snackInfo } = useSnackMessage();
 
-    const [openExportDialog, setOpenExport] = React.useState(false);
+    const [openExportDialog, setOpenExport] = useState(false);
 
-    const [openReportViewer, setOpenReportViewer] = React.useState(false);
-    const [report, setReport] = React.useState(null);
+    const [openReportViewer, setOpenReportViewer] = useState(false);
+    const [report, setReport] = useState(null);
 
     const handleCloseExport = () => {
         setOpenExport(false);
@@ -213,129 +209,102 @@ const StepperWithStatus = (props) => {
     }, [stepper]);
 
     return (
-        <Grid
-            container
-            direction="row"
-            className={classes.stepperGridContainer}
-        >
+        <Grid container direction="row" sx={classes.stepperGridContainer}>
             <Grid item xs={12} md={2} />
-            <Grid
-                item
-                xs={12}
-                md={1}
-                className={
-                    classes.stepperButtonContainer +
-                    ' ' +
-                    classes.stepperGridMargins
-                }
-            >
+            <Grid item xs={12} md={1} sx={classes2.stepperButtonContainer}>
                 <IconButton
                     aria-label="replace"
-                    className={classes.stepperButton}
+                    sx={classes.stepperButton}
                     onClick={handleReplaceIGM}
                     disabled={!replaceIGMEnabled}
                 >
                     <BuildIcon
                         fontSize="large"
-                        className={classes.stepperButtonIcon}
+                        sx={classes.stepperButtonIcon}
                     />
                 </IconButton>
-                <span
-                    className={
-                        !replaceIGMEnabled
-                            ? classes.buttonLabelDisabled
-                            : classes.buttonLabelEnabled
+                <Box
+                    component="span"
+                    sx={
+                        replaceIGMEnabled
+                            ? classes.buttonLabelEnabled
+                            : classes.buttonLabelDisabled
                     }
                 >
                     <FormattedMessage id="replaceIGM" />
-                </span>
+                </Box>
             </Grid>
-            <Grid item xs={12} md={5} className={classes.stepperGridMargins}>
-                <CustomStepper>
+            <Grid item xs={12} md={5} sx={classes.stepperGridMargins}>
+                <Stepper sx={classes.stepper}>
                     <Step active={availableStep}>
-                        <CustomStepLabel className={classes.stepLabel}>
+                        <StepLabel sx={classes.stepLabel}>
                             <FormattedMessage id="igmReception" />
-                        </CustomStepLabel>
+                        </StepLabel>
                     </Step>
                     <Step active={validStep}>
-                        <CustomStepLabel className={classes.stepLabel}>
+                        <StepLabel sx={classes.stepLabel}>
                             <FormattedMessage id="imgMerged" />
-                        </CustomStepLabel>
+                        </StepLabel>
                     </Step>
                     <Step active={mergedStep}>
-                        <CustomStepLabel className={classes.stepLabel}>
+                        <StepLabel sx={classes.stepLabel}>
                             <FormattedMessage id="cgmValid" />
-                        </CustomStepLabel>
+                        </StepLabel>
                     </Step>
-                </CustomStepper>
+                </Stepper>
             </Grid>
-            <Grid
-                item
-                xs={12}
-                md={1}
-                className={
-                    classes.stepperButtonContainer +
-                    ' ' +
-                    classes.stepperGridMargins
-                }
-            >
+            <Grid item xs={12} md={1} sx={classes2.stepperButtonContainer}>
                 <IconButton
                     aria-label="report"
-                    className={classes.stepperButton}
+                    sx={classes.stepperButton}
                     onClick={handleClickShowReport}
                     disabled={!mergedStep}
                 >
                     <AccountTreeIcon
                         fontSize="large"
-                        className={classes.stepperButtonIcon}
+                        sx={classes.stepperButtonIcon}
                     />
                 </IconButton>
-                <span
-                    className={
-                        !mergedStep
-                            ? classes.buttonLabelDisabled
-                            : classes.buttonLabelEnabled
+                <Box
+                    component="span"
+                    sx={
+                        mergedStep
+                            ? classes.buttonLabelEnabled
+                            : classes.buttonLabelDisabled
                     }
                 >
                     <FormattedMessage id="showReport" />
-                </span>
+                </Box>
             </Grid>
-            <Grid
-                item
-                xs={12}
-                md={1}
-                className={
-                    classes.stepperButtonContainer +
-                    ' ' +
-                    classes.stepperGridMargins
-                }
-            >
+            <Grid item xs={12} md={1} sx={classes2.stepperButtonContainer}>
                 <IconButton
                     aria-label="download"
-                    className={classes.stepperButton}
+                    sx={classes.stepperButton}
                     onClick={handleOpenExport}
                     disabled={!mergedStep}
                 >
                     <GetAppIcon
                         fontSize="large"
-                        className={classes.stepperButtonIcon}
+                        sx={classes.stepperButtonIcon}
                     />
                 </IconButton>
-                <iframe
+                <Box
+                    component="iframe"
                     title="download"
                     id={DownloadIframe}
                     name={DownloadIframe}
-                    className={classes.iframe}
+                    sx={classes.iframe}
                 />
-                <span
-                    className={
-                        !mergedStep
-                            ? classes.buttonLabelDisabled
-                            : classes.buttonLabelEnabled
+                <Box
+                    component="span"
+                    sx={
+                        mergedStep
+                            ? classes.buttonLabelEnabled
+                            : classes.buttonLabelDisabled
                     }
                 >
                     <FormattedMessage id="downloadCgm" />
-                </span>
+                </Box>
             </Grid>
             <Grid item xs={12} md={2} />
             {report && (
@@ -355,8 +324,8 @@ const StepperWithStatus = (props) => {
                 open={openExportDialog}
                 onClose={handleCloseExport}
                 onClick={handleClickExport}
-                processUuid={props.merge && props.merge.processUuid}
-                date={props.merge && props.merge.date}
+                processUuid={props.merge?.processUuid}
+                date={props.merge?.date}
                 title={intl.formatMessage({ id: 'exportNetwork' })}
                 getDownloadUrl={getExportMergeUrl}
                 formats={availableFormats}

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { PARAM_TIMELINE_DIAGONAL_LABELS } from '../utils/config-params';
 
-const classes = {
+const styles = {
     customSlider: {
         padding: '10px 20px',
         width: '100%',
@@ -158,9 +158,9 @@ const Timeline = (props) => {
     const TheSlider = empty ? EmptySlider : ClockSlider;
 
     return (
-        <Box sx={classes.customSlider}>
+        <Box sx={styles.customSlider}>
             <TheSlider
-                sx={timelineDiagonalLabels ? classes.obliqueLabels : undefined}
+                sx={timelineDiagonalLabels ? styles.obliqueLabels : undefined}
                 value={value}
                 marks={marks}
                 onChangeCommitted={handleSliderChange}

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -5,19 +5,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect, useState } from 'react';
-
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-
-import makeStyles from '@mui/styles/makeStyles';
-import withStyles from '@mui/styles/withStyles';
-import Slider from '@mui/material/Slider';
+import { Box, Slider, withStyles } from '@mui/material';
 import ClockIcon from '../images/clock.svg';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { PARAM_TIMELINE_DIAGONAL_LABELS } from '../utils/config-params';
 
-const useStyles = makeStyles((theme) => ({
+const classes = {
     customSlider: {
         padding: '10px 20px',
         width: '100%',
@@ -30,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
             margin: '15px 0 0 -25px',
         },
     },
-}));
+};
 
 const EmptySlider = withStyles((theme) => ({
     root: {
@@ -102,8 +98,6 @@ const ClockSlider = withStyles((theme) => ({
 }))(EmptySlider);
 
 const Timeline = (props) => {
-    const classes = useStyles();
-
     const [marks, setMarks] = useState([]);
 
     const [value, setValue] = useState(null);
@@ -164,23 +158,19 @@ const Timeline = (props) => {
     const TheSlider = empty ? EmptySlider : ClockSlider;
 
     return (
-        <>
-            <div className={classes.customSlider}>
-                <TheSlider
-                    className={
-                        timelineDiagonalLabels ? classes.obliqueLabels : ''
-                    }
-                    value={value}
-                    marks={marks}
-                    onChangeCommitted={handleSliderChange}
-                    min={0}
-                    step={null}
-                    max={24 * 60 - 1}
-                    valueLabelFormat={getValueLabelFormat}
-                    disabled={empty}
-                />
-            </div>
-        </>
+        <Box sx={classes.customSlider}>
+            <TheSlider
+                sx={timelineDiagonalLabels ? classes.obliqueLabels : undefined}
+                value={value}
+                marks={marks}
+                onChangeCommitted={handleSliderChange}
+                min={0}
+                step={null}
+                max={24 * 60 - 1}
+                valueLabelFormat={getValueLabelFormat}
+                disabled={empty}
+            />
+        </Box>
     );
 };
 

--- a/src/utils/dialogs.js
+++ b/src/utils/dialogs.js
@@ -21,7 +21,7 @@ import {
 } from '@mui/material';
 import PropTypes from 'prop-types';
 
-const classes = {
+const styles = {
     formControl: {
         minWidth: 300,
     },
@@ -87,7 +87,7 @@ const ExportDialog = ({
         >
             <DialogTitle>{title}</DialogTitle>
             <DialogContent>
-                <FormControl sx={classes.formControl}>
+                <FormControl sx={styles.formControl}>
                     <InputLabel id="select-format-label">
                         <FormattedMessage id="exportFormat" />
                     </InputLabel>

--- a/src/utils/dialogs.js
+++ b/src/utils/dialogs.js
@@ -5,23 +5,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
+    Alert,
     Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
     FormControl,
+    InputLabel,
     MenuItem,
+    Select,
 } from '@mui/material';
 import PropTypes from 'prop-types';
-import React from 'react';
-import { Select, InputLabel } from '@mui/material';
 
-import makeStyles from '@mui/styles/makeStyles';
-
-import Alert from '@mui/material/Alert';
+const classes = {
+    formControl: {
+        minWidth: 300,
+    },
+};
 
 /**
  * Dialog to export the network case #TODO To be moved in the common-ui repository once it has been created
@@ -43,16 +47,8 @@ const ExportDialog = ({
     formats,
     errorMessage,
 }) => {
-    const [selectedFormat, setSelectedFormat] = React.useState('');
-    const [exportStudyErr, setExportStudyErr] = React.useState('');
-
-    const useStyles = makeStyles(() => ({
-        formControl: {
-            minWidth: 300,
-        },
-    }));
-
-    const classes = useStyles();
+    const [selectedFormat, setSelectedFormat] = useState('');
+    const [exportStudyErr, setExportStudyErr] = useState('');
 
     const handleClick = () => {
         console.debug('Request for exporting in format: ' + selectedFormat);
@@ -91,7 +87,7 @@ const ExportDialog = ({
         >
             <DialogTitle>{title}</DialogTitle>
             <DialogContent>
-                <FormControl className={classes.formControl}>
+                <FormControl sx={classes.formControl}>
                     <InputLabel id="select-format-label">
                         <FormattedMessage id="exportFormat" />
                     </InputLabel>
@@ -104,14 +100,13 @@ const ExportDialog = ({
                             id: 'select-format',
                         }}
                     >
-                        {formats &&
-                            formats.map(function (element) {
-                                return (
-                                    <MenuItem key={element} value={element}>
-                                        {element}
-                                    </MenuItem>
-                                );
-                            })}
+                        {formats?.map(function (element) {
+                            return (
+                                <MenuItem key={element} value={element}>
+                                    {element}
+                                </MenuItem>
+                            );
+                        })}
                     </Select>
                 </FormControl>
                 {exportStudyErr && (


### PR DESCRIPTION
Remove `@mui/styles/*` usages (replace by emotion for simple styling).

Also have to temporally resolve typescript version conflict use by react-scripts, dependent to typescript@^4, until the migration to Vite.

Ref gridsuite/commons-ui#350